### PR TITLE
remove lodash (_.map)

### DIFF
--- a/lib/models/job.js
+++ b/lib/models/job.js
@@ -112,7 +112,7 @@ module.exports = {
         }
         if (type === 'wait' || type === 'active') {
             return q.getJobs(type, 'LIST', true, offset, offset + limit - 1).then(function (jobs) {
-                return Promise.all(_.map(jobs, function (job) {
+                return Promise.all(jobs.map(function (job) {
                     if (!job) {
                         return null;
                     }
@@ -124,7 +124,7 @@ module.exports = {
             });
         } else if (type === 'delayed' || type === 'failed' || type === 'completed') {
             return q.getJobs(type, 'ZSET', false, offset, offset + limit - 1).then(function (jobs) {
-                return Promise.all(_.map(jobs, function (job) {
+                return Promise.all(jobs.map(function (job) {
                     if (!job) {
                         return null;
                     }

--- a/lib/models/job.js
+++ b/lib/models/job.js
@@ -1,4 +1,3 @@
-var _ = require('lodash');
 var redis = require('../redis');
 var queue = require('./queue');
 

--- a/lib/models/queue.js
+++ b/lib/models/queue.js
@@ -1,4 +1,3 @@
-var _ = require('lodash');
 var bull = require('bull');
 var redis = require('../redis');
 

--- a/lib/models/queue.js
+++ b/lib/models/queue.js
@@ -21,7 +21,7 @@ module.exports = {
     list: function () {
         var client = redis.client();
         return client.keysAsync('bull:*:id').then(function (keys) {
-            return _.map(keys, function (key) {
+            return keys.map(function (key) {
                 return key.slice(5, -3);
             });
         });

--- a/lib/routes/job.js
+++ b/lib/routes/job.js
@@ -1,4 +1,3 @@
-var _ = require('lodash');
 var express = require('express');
 var router = express.Router();
 var Queue = require('../models/queue');

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "express": "4.15.x",
     "highlight.js": "8.8.x",
     "jquery": "3.0.x",
-    "lodash": "3.10.x",
     "minimist": "1.2.x",
     "moment-timezone": "0.5.x",
     "pug": "2.0.0-beta6",

--- a/tests/test_models.js
+++ b/tests/test_models.js
@@ -1,4 +1,3 @@
-var _ = require('lodash');
 var bull = require('bull');
 var chai = require('chai');
 var expect = chai.expect;

--- a/tests/test_models.js
+++ b/tests/test_models.js
@@ -137,7 +137,7 @@ describe('Models', function () {
                     expect(jobs.length).to.equal(7);
                     // ids are reversed since it's LIFO
                     var ids = [15, 14, 13];
-                    _.map(jobs, function (job) {
+                    jobs.map(function (job) {
                         expect(ids.indexOf(Number(job.id))).to.equal(-1);
                     });
                     done();
@@ -176,7 +176,7 @@ describe('Models', function () {
                     expect(jobs).to.be.an('array');
                     expect(jobs.length).to.equal(3);
                     var ids = [2, 3, 4];
-                    _.map(jobs, function (job) {
+                    jobs.map(function (job) {
                         expect(ids.indexOf(Number(job.id))).to.not.equal(-1);
                     });
                     done();
@@ -217,7 +217,7 @@ describe('Models', function () {
                     expect(jobs).to.be.an('array');
                     expect(jobs.length).to.equal(4);
                     var ids = [1, 2, 3, 4];
-                    _.map(jobs, function (job) {
+                    jobs.map(function (job) {
                         expect(ids.indexOf(Number(job.id))).to.equal(-1);
                     });
                     done();
@@ -255,7 +255,7 @@ describe('Models', function () {
                     expect(jobs).to.be.an('array');
                     expect(jobs.length).to.equal(5);
                     var ids = [2, 3, 4, 5, 6];
-                    _.map(jobs, function (job) {
+                    jobs.map(function (job) {
                         expect(ids.indexOf(Number(job.id))).to.equal(-1);
                     });
                     done();
@@ -294,7 +294,7 @@ describe('Models', function () {
                     expect(jobs).to.be.an('array');
                     expect(jobs.length).to.equal(7);
                     var ids = [4, 5, 6, 7, 8, 9, 10];
-                    _.map(jobs, function (job) {
+                    jobs.map(function (job) {
                         expect(ids.indexOf(Number(job.id))).to.equal(-1);
                     });
                     done();

--- a/tests/test_server.js
+++ b/tests/test_server.js
@@ -1,4 +1,3 @@
-var _ = require('lodash');
 var bull = require('bull');
 var chai = require('chai');
 var expect = chai.expect;


### PR DESCRIPTION
Hello,

this is my proposal to remove the `_.map` helper from lodash, since the native `.map` function can be used :)

This removes the dependency from [`lodash`](https://www.npmjs.com/package/lodash).

Thanks for the great work.

PS: I would like to contribute to the project. Would you be interested in spending some time on it, maybe in the next months?